### PR TITLE
feat: migrate to AWS SDK v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "dev": "npm run build && node ./build/bin/acady.js"
   },
   "devDependencies": {
+    "@aws-sdk/client-apigatewayv2": "^3.743.0",
+    "@aws-sdk/client-iam": "^3.743.0",
+    "@aws-sdk/client-lambda": "^3.743.0",
+    "@aws-sdk/credential-provider-node": "^3.743.0",
+    "@aws-sdk/types": "^3.734.0",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.19",
     "@types/sha256": "^0.2.0",
@@ -36,7 +41,6 @@
     "acady-api-builder": "^1.2.2",
     "ansi-regex": "^6.0.1",
     "archiver": "^4.0.2",
-    "aws-sdk": "^2.814.0",
     "chalk": "^4.1.0",
     "cli-table": "^0.3.4",
     "colors": "1.4.0",
@@ -76,6 +80,14 @@
     "webdev",
     "devops"
   ],
+  "peerDependencies": {
+    "@aws-sdk/client-apigatewayv2": "^3.0.0",
+    "@aws-sdk/client-iam": "^3.0.0",
+    "@aws-sdk/client-lambda": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=14"
+  },
   "jest": {
     "transform": {
       ".(ts|tsx)": "ts-jest"

--- a/src/connectors/aws-gateway-connector.ts
+++ b/src/connectors/aws-gateway-connector.ts
@@ -1,69 +1,59 @@
-import {Credentials, ApiGatewayV2, Lambda} from "aws-sdk";
+import { 
+    ApiGatewayV2Client,
+    CreateApiCommand,
+    CreateRouteCommand,
+    CreateIntegrationCommand,
+    CreateStageCommand,
+    UpdateApiCommand,
+    UpdateRouteCommand,
+    CreateApiCommandInput,
+    CreateApiCommandOutput,
+    CreateRouteCommandInput,
+    CreateRouteCommandOutput,
+    CreateIntegrationCommandInput,
+    CreateIntegrationCommandOutput,
+    CreateStageCommandInput,
+    CreateStageCommandOutput,
+    UpdateApiCommandInput,
+    UpdateApiCommandOutput,
+    UpdateRouteCommandInput,
+    UpdateRouteCommandOutput
+} from "@aws-sdk/client-apigatewayv2";
+import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 export class AwsGatewayConnector {
-
-    public static createApi(credentials: Credentials, region: string, params: ApiGatewayV2.CreateApiRequest): Promise<ApiGatewayV2.CreateApiResponse> {
+    public static async createApi(credentials: AwsCredentialIdentity, region: string, params: CreateApiCommandInput): Promise<CreateApiCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createApi(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new CreateApiCommand(params));
     }
 
-    public static createRoute(credentials: Credentials, region: string, params: ApiGatewayV2.CreateRouteRequest): Promise<ApiGatewayV2.CreateRouteResult> {
+    public static async createRoute(credentials: AwsCredentialIdentity, region: string, params: CreateRouteCommandInput): Promise<CreateRouteCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createRoute(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new CreateRouteCommand(params));
     }
 
-    public static createIntegration(credentials: Credentials, region: string, params: ApiGatewayV2.CreateIntegrationRequest): Promise<ApiGatewayV2.CreateIntegrationResult> {
+    public static async createIntegration(credentials: AwsCredentialIdentity, region: string, params: CreateIntegrationCommandInput): Promise<CreateIntegrationCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createIntegration(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new CreateIntegrationCommand(params));
     }
 
-    public static createStage(credentials: Credentials, region: string, params: ApiGatewayV2.CreateStageRequest): Promise<ApiGatewayV2.CreateStageResponse> {
+    public static async createStage(credentials: AwsCredentialIdentity, region: string, params: CreateStageCommandInput): Promise<CreateStageCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createStage(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new CreateStageCommand(params));
     }
 
-    public static updateApi(credentials: Credentials, region: string, params: ApiGatewayV2.UpdateApiRequest): Promise<ApiGatewayV2.UpdateApiResponse> {
+    public static async updateApi(credentials: AwsCredentialIdentity, region: string, params: UpdateApiCommandInput): Promise<UpdateApiCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.updateApi(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new UpdateApiCommand(params));
     }
 
-    public static updateRoute(credentials: Credentials, region: string, params: ApiGatewayV2.UpdateRouteRequest): Promise<ApiGatewayV2.UpdateRouteResult> {
+    public static async updateRoute(credentials: AwsCredentialIdentity, region: string, params: UpdateRouteCommandInput): Promise<UpdateRouteCommandOutput> {
         const client = AwsGatewayConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.updateRoute(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new UpdateRouteCommand(params));
     }
 
-    private static getClient(credentials: Credentials, region: string): ApiGatewayV2 {
-        return new ApiGatewayV2({
+    private static getClient(credentials: AwsCredentialIdentity, region: string): ApiGatewayV2Client {
+        return new ApiGatewayV2Client({
             region,
             credentials
         });

--- a/src/connectors/aws-iam-connector.ts
+++ b/src/connectors/aws-iam-connector.ts
@@ -1,58 +1,51 @@
-import {Credentials, IAM} from "aws-sdk";
+import { 
+    IAMClient, 
+    GetUserCommand,
+    CreateRoleCommand, 
+    CreatePolicyCommand,
+    AttachRolePolicyCommand,
+    GetUserCommandOutput,
+    CreateRoleCommandOutput,
+    CreatePolicyCommandOutput,
+    AttachRolePolicyCommandOutput
+} from "@aws-sdk/client-iam";
+import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 export class AwsIamConnector {
-
-    public static async getCurrentUser(credentials: Credentials): Promise<IAM.User> {
+    public static async getCurrentUser(credentials: AwsCredentialIdentity): Promise<GetUserCommandOutput['User']> {
         const client = AwsIamConnector.getClient(credentials);
-        return new Promise((resolve, reject) => {
-            client.getUser({},(err, data) => {
-                if (err) reject(err);
-                else resolve(data.User)
-            });
-        });
+        const response = await client.send(new GetUserCommand({}));
+        return response.User;
     }
 
-    public static async createRole(credentials: Credentials, roleName: string, assumeRolePolicy: any): Promise<IAM.Role>  {
+    public static async createRole(credentials: AwsCredentialIdentity, roleName: string, assumeRolePolicy: any): Promise<CreateRoleCommandOutput['Role']> {
         const client = AwsIamConnector.getClient(credentials);
-        return new Promise((resolve, reject) => {
-            client.createRole({
-                RoleName: roleName,
-                AssumeRolePolicyDocument: JSON.stringify(assumeRolePolicy)
-            },(err, data) => {
-                if (err) reject(err);
-                else resolve(data.Role)
-            });
-        });
+        const response = await client.send(new CreateRoleCommand({
+            RoleName: roleName,
+            AssumeRolePolicyDocument: JSON.stringify(assumeRolePolicy)
+        }));
+        return response.Role;
     }
 
-    public static async createPolicy(credentials: Credentials, policyName: string, policy: any): Promise<IAM.Policy>  {
+    public static async createPolicy(credentials: AwsCredentialIdentity, policyName: string, policy: any): Promise<CreatePolicyCommandOutput['Policy']> {
         const client = AwsIamConnector.getClient(credentials);
-        return new Promise((resolve, reject) => {
-            client.createPolicy({
-                PolicyName: policyName,
-                PolicyDocument: JSON.stringify(policy)
-            },(err, data) => {
-                if (err) reject(err);
-                else resolve(data.Policy)
-            });
-        });
+        const response = await client.send(new CreatePolicyCommand({
+            PolicyName: policyName,
+            PolicyDocument: JSON.stringify(policy)
+        }));
+        return response.Policy;
     }
 
-    public static async attachRolePolicy(credentials: Credentials, roleName: string, policyArn: string): Promise<IAM.Policy>  {
+    public static async attachRolePolicy(credentials: AwsCredentialIdentity, roleName: string, policyArn: string): Promise<AttachRolePolicyCommandOutput> {
         const client = AwsIamConnector.getClient(credentials);
-        return new Promise((resolve, reject) => {
-            client.attachRolePolicy({
-                RoleName: roleName,
-                PolicyArn: policyArn
-            },(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new AttachRolePolicyCommand({
+            RoleName: roleName,
+            PolicyArn: policyArn
+        }));
     }
 
-    private static getClient(credentials: Credentials): IAM {
-        return new IAM({
+    private static getClient(credentials: AwsCredentialIdentity): IAMClient {
+        return new IAMClient({
             credentials
         });
     }

--- a/src/connectors/aws-lambda-connector.ts
+++ b/src/connectors/aws-lambda-connector.ts
@@ -1,102 +1,78 @@
-import {Credentials, Lambda} from "aws-sdk";
+import { 
+    LambdaClient,
+    ListFunctionsCommand,
+    CreateFunctionCommand,
+    AddPermissionCommand,
+    CreateAliasCommand,
+    UpdateAliasCommand,
+    UpdateFunctionCodeCommand,
+    UpdateFunctionConfigurationCommand,
+    ListFunctionsCommandOutput,
+    FunctionConfiguration,
+    AddPermissionCommandOutput,
+    AliasConfiguration,
+    CreateFunctionRequest,
+    AddPermissionRequest,
+    UpdateFunctionCodeRequest,
+    UpdateFunctionConfigurationRequest
+} from "@aws-sdk/client-lambda";
+import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 class AwsLambdaConnector {
-
-
-    public static listFunctions(credentials: Credentials, region: string, marker?: string): Promise<Lambda.ListFunctionsResponse> {
+    public static async listFunctions(credentials: AwsCredentialIdentity, region: string, marker?: string): Promise<ListFunctionsCommandOutput> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-
-        const params = {
-            Marker: marker
-        };
-
-        return new Promise((resolve, reject) => {
-            client.listFunctions(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new ListFunctionsCommand({ Marker: marker }));
     }
 
-
-    public static createFunction(credentials: Credentials, region: string, params: Lambda.Types.CreateFunctionRequest): Promise<Lambda.FunctionConfiguration> {
+    public static async createFunction(credentials: AwsCredentialIdentity, region: string, params: CreateFunctionRequest): Promise<FunctionConfiguration> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createFunction(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        const response = await client.send(new CreateFunctionCommand(params));
+        return response;
     }
 
-    public static addPermission(credentials: Credentials, region: string, params: Lambda.Types.AddPermissionRequest): Promise<Lambda.AddPermissionResponse> {
+    public static async addPermission(credentials: AwsCredentialIdentity, region: string, params: AddPermissionRequest): Promise<AddPermissionCommandOutput> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.addPermission(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        return client.send(new AddPermissionCommand(params));
     }
 
-    public static createAlias(credentials: Credentials, region: string, functionName: string, functionVersion: string, aliasName: string): Promise<Lambda.AliasConfiguration> {
+    public static async createAlias(credentials: AwsCredentialIdentity, region: string, functionName: string, functionVersion: string, aliasName: string): Promise<AliasConfiguration> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.createAlias({
-                FunctionName: functionName,
-                FunctionVersion: functionVersion,
-                Name: aliasName
-            },(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        const response = await client.send(new CreateAliasCommand({
+            FunctionName: functionName,
+            FunctionVersion: functionVersion,
+            Name: aliasName
+        }));
+        return response;
     }
 
-    public static updateAlias(credentials: Credentials, region: string, functionName: string, functionVersion: string, aliasName: string): Promise<Lambda.AliasConfiguration> {
+    public static async updateAlias(credentials: AwsCredentialIdentity, region: string, functionName: string, functionVersion: string, aliasName: string): Promise<AliasConfiguration> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.updateAlias({
-                FunctionName: functionName,
-                FunctionVersion: functionVersion,
-                Name: aliasName
-            },(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        const response = await client.send(new UpdateAliasCommand({
+            FunctionName: functionName,
+            FunctionVersion: functionVersion,
+            Name: aliasName
+        }));
+        return response;
     }
 
-    public static updateFunctionCode(credentials: Credentials, region: string, params: Lambda.Types.UpdateFunctionCodeRequest): Promise<Lambda.FunctionConfiguration>  {
+    public static async updateFunctionCode(credentials: AwsCredentialIdentity, region: string, params: UpdateFunctionCodeRequest): Promise<FunctionConfiguration> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.updateFunctionCode(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        const response = await client.send(new UpdateFunctionCodeCommand(params));
+        return response;
     }
 
-    public static updateFunctionConfig(credentials: Credentials, region: string, params: Lambda.Types.UpdateFunctionConfigurationRequest): Promise<Lambda.FunctionConfiguration>  {
+    public static async updateFunctionConfig(credentials: AwsCredentialIdentity, region: string, params: UpdateFunctionConfigurationRequest): Promise<FunctionConfiguration> {
         const client = AwsLambdaConnector.getClient(credentials, region);
-        return new Promise((resolve, reject) => {
-            client.updateFunctionConfiguration(params,(err, data) => {
-                if (err) reject(err);
-                else resolve(data)
-            });
-        });
+        const response = await client.send(new UpdateFunctionConfigurationCommand(params));
+        return response;
     }
 
-
-
-
-    private static getClient(credentials: Credentials, region: string): Lambda {
-        return new Lambda({
+    private static getClient(credentials: AwsCredentialIdentity, region: string): LambdaClient {
+        return new LambdaClient({
             region,
             credentials
         });
     }
-
 }
 
-export {AwsLambdaConnector};
+export { AwsLambdaConnector };

--- a/src/helpers/credentials/aws-credentials-helper.ts
+++ b/src/helpers/credentials/aws-credentials-helper.ts
@@ -1,12 +1,12 @@
-import {Credentials} from "aws-sdk";
-import {AwsLambdaConnector} from "../../connectors/aws-lambda-connector";
+import { AwsCredentialIdentity } from "@aws-sdk/types";
+import { AwsLambdaConnector } from "../../connectors/aws-lambda-connector";
 import logSymbols = require("log-symbols");
-import {AwsIamConnector} from "../../connectors/aws-iam-connector";
-import {StringHelper} from "../string-helper";
+import { AwsIamConnector } from "../../connectors/aws-iam-connector";
+import { StringHelper } from "../string-helper";
 
 class AwsCredentialsHelper {
 
-    public static async verify(credentials: Credentials): Promise<string> {
+    public static async verify(credentials: AwsCredentialIdentity): Promise<string> {
         try {
             const functions = await AwsLambdaConnector.listFunctions(credentials, 'us-east-1');
             if (!Array.isArray(functions.Functions))

--- a/src/services/account-service.ts
+++ b/src/services/account-service.ts
@@ -1,7 +1,6 @@
 import {StorageService} from "./storage-service";
 import {Account} from "../dto/account";
 import {nanoid} from 'nanoid';
-import {account} from "aws-sdk/clients/sns";
 
 class AccountService {
     public static listAccounts(type?: string): Account[] {


### PR DESCRIPTION
Migration from AWS SDK v2 to v3.

Changes:
- Remove aws-sdk v2 dependency
- Add AWS SDK v3 client packages as peer/dev dependencies
- Update IAM, Lambda, and API Gateway connectors to v3
- Remove unused SNS import
- Update credential types to use AWS SDK v3

Notes:
1. DynamoDB types in dynamodb-entity-code-generator.ts are pending confirmation of acady-connector-dynamodb compatibility
2. Test coverage is minimal (only tests FileHelper.replaceSymlinks) and doesn't cover AWS SDK functionality
3. Set minimum Node.js version to 14+ as required by AWS SDK v3

Link to Devin run: https://app.devin.ai/sessions/baa9572d855a40d2b4c73609c8018d26
Requested by: Christian